### PR TITLE
Draft: Set XSRF cookie on API request

### DIFF
--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -106,6 +106,8 @@ class LoginHandler(JupyterHandler):
             cookie_options.setdefault("secure", True)
         cookie_options.setdefault("path", handler.base_url)
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
+        # To set XSRF token at login
+        self.xsrf_token
         return user_id
 
     auth_header_pat = re.compile(r"token\s+(.+)", re.IGNORECASE)

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -107,7 +107,7 @@ class LoginHandler(JupyterHandler):
         cookie_options.setdefault("path", handler.base_url)
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
         # To set XSRF token at login
-        self.xsrf_token
+        handler.xsrf_token
         return user_id
 
     auth_header_pat = re.compile(r"token\s+(.+)", re.IGNORECASE)

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -107,6 +107,7 @@ class LoginHandler(JupyterHandler):
         cookie_options.setdefault("path", handler.base_url)
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
         # To set _xsrf cookie at login
+        handler.current_user = handler._jupyter_current_user = user_id
         handler.xsrf_token
         return user_id
 

--- a/jupyter_server/auth/login.py
+++ b/jupyter_server/auth/login.py
@@ -106,7 +106,7 @@ class LoginHandler(JupyterHandler):
             cookie_options.setdefault("secure", True)
         cookie_options.setdefault("path", handler.base_url)
         handler.set_secure_cookie(handler.cookie_name, user_id, **cookie_options)
-        # To set XSRF token at login
+        # To set _xsrf cookie at login
         handler.xsrf_token
         return user_id
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -706,6 +706,7 @@ class APIHandler(JupyterHandler):
 
     async def prepare(self):
         await super().prepare()
+        self.xsrf_token
         if not self.check_origin():
             raise web.HTTPError(404)
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -706,7 +706,6 @@ class APIHandler(JupyterHandler):
 
     async def prepare(self):
         await super().prepare()
-        self.xsrf_token
         if not self.check_origin():
             raise web.HTTPError(404)
 

--- a/jupyter_server/base/handlers.py
+++ b/jupyter_server/base/handlers.py
@@ -133,6 +133,7 @@ class AuthenticatedHandler(web.RequestHandler):
             # N.B. This bypasses the normal cookie handling, which can't update
             # two cookies with the same name. See the method above.
             self.force_clear_cookie(self.cookie_name)
+        self.clear_cookie("_xsrf")
 
     def get_current_user(self):
         clsname = self.__class__.__name__


### PR DESCRIPTION
https://github.com/jupyter-server/jupyter_server/issues/746

To solve the issue, add access xsrf_token in prepare.